### PR TITLE
Add Behavior system

### DIFF
--- a/addons/godot-next/godot_next_plugin.gd
+++ b/addons/godot-next/godot_next_plugin.gd
@@ -1,2 +1,13 @@
 tool
 extends EditorPlugin
+
+const ResourceCollectionInspectorPlugin = preload("res://addons/godot-next/inspector_plugins/resource_collection_inspector_plugin.gd")
+
+var resource_collection_inspector_plugin
+
+func _enter_tree() -> void:
+	resource_collection_inspector_plugin = ResourceCollectionInspectorPlugin.new()
+	add_inspector_plugin(resource_collection_inspector_plugin)
+
+func _exit_tree() -> void:
+	remove_inspector_plugin(resource_collection_inspector_plugin)

--- a/addons/godot-next/inspector_plugins/resource_collection_inspector_plugin.gd
+++ b/addons/godot-next/inspector_plugins/resource_collection_inspector_plugin.gd
@@ -1,0 +1,86 @@
+# author: xdgamestudios
+# license: MIT
+# description: This script is injected into the editor upon loading the plugin,
+#              allowing for resource collections GUI to work in the inspector.
+tool
+extends EditorInspectorPlugin
+
+##### CONSTANTS #####
+
+const ADD_ICON = preload("res://addons/godot-next/icons/icon_add.svg")
+
+##### PROPERTIES #####
+
+##### NOTIFICATIONS #####
+
+##### VIRTUALS #####
+
+#warning-ignore:unused_argument
+func can_handle(p_object) -> bool:
+	return true
+
+#warning-ignore:unused_argument
+func parse_property(p_object, p_type, p_path, p_hint, p_hint_text, p_usage) -> bool:
+	match p_type:
+		TYPE_ARRAY, TYPE_DICTIONARY:
+			if p_hint == PROPERTY_HINT_RESOURCE_TYPE and p_hint_text.begins_with("#"):
+				add_custom_control(_generate_gui(p_object, p_path, p_hint_text.lstrip("#")))
+				return true
+	return false
+
+##### PRIVATE METHODS #####
+
+func _find_inheritors(p_type_path: String) -> Array:
+	var ct = ClassType.new(p_type_path, true)
+	var list = ct.get_deep_inheritors_list()
+	var type_map = ct.get_deep_type_map()
+	var scripts = []
+	for a_name in list:
+		scripts.append(load(type_map[a_name].path))
+	return scripts
+
+func _generate_gui(p_object: Object, p_path: String, p_type_path: String) -> Control:
+	
+	var hbox := HBoxContainer.new()
+	
+	var elements := _find_inheritors(p_type_path)
+	
+	var dropdown := _generate_type_dropdown(elements)
+	var button := _generate_add_button()
+	
+	#warning-ignore:return_value_discarded
+	button.connect("pressed", self, "_on_add_button_pressed", [p_object, p_path, dropdown])
+
+	dropdown.size_flags_horizontal = HBoxContainer.SIZE_EXPAND_FILL
+	
+	hbox.add_child(dropdown)
+	hbox.add_child(button)
+	
+	return hbox
+
+func _generate_type_dropdown(p_elements: Array) -> Control:
+	var dropdown := OptionButton.new()
+	
+	for i in p_elements.size():
+		var ct = ClassType.new(p_elements[i])
+		dropdown.add_item(ct.get_name(), i)
+		dropdown.set_item_metadata(i, p_elements[i])
+	
+	return dropdown
+
+func _generate_add_button() -> Control:
+	var button = ToolButton.new()
+	button.icon = ADD_ICON
+	return button
+
+##### CONNECTIONS #####
+
+func _on_add_button_pressed(p_object: Object, p_path: String, p_dropdown: OptionButton):
+	var index := p_dropdown.get_selected_id()
+	var script: Script = p_dropdown.get_item_metadata(index) as Script
+	
+	if p_object.has_method("_add_element"):
+		p_object.call("_add_element", p_path, script)
+	else:
+		push_warning("The ResourceCollection at <%s> does not implement '_add_element(variable: String, script: Script)'." % p_object.get_script().resource_path)
+	p_object.property_list_changed_notify()

--- a/addons/godot-next/nodes/behaviors.gd
+++ b/addons/godot-next/nodes/behaviors.gd
@@ -1,0 +1,175 @@
+# author: xdgamestudios
+# license: MIT
+# description: Provides a behavior system API for the nodes. 
+# todo: Refactor code in general to clean and improve performance
+# usage:
+# - Creating:
+#     behaviors = Behaviors.new()
+# - Adding Behaviors:
+#     behaviors.add_behavior(MyBehavior) # Returns null if the user assigns an invalid Behavior class.
+#     Note:
+#     - Allows only one behavior of each type.
+#     - If behavior already exists pre-existing Behavior is returned.
+# - Checking Behaviors:
+#     behaviors.has_behavior(MyBehavior) # Returns true if behavior exists within the collection.
+# - Retrieving Behaviors:
+#     behaviors.get_behavior(MyBehavior) # Returns the existing instance of the behavior type.
+#     Note:
+#     - If behavior doesn't exist in the collection returns null.
+# - Removing Behaviors:
+#     behaviors.remove_behavior(MyBehavior) # Removes the Behavior from the collection.
+#     Note:
+#     - Returns true if successful. Else, returns false.
+tool
+extends Node
+class_name Behaviors
+
+##### PROPERTIES #####
+
+var _behaviors: ResourceSet = null
+
+var _callbacks: Dictionary = {
+	"_ready" : {},
+	"_process" : {},
+	"_physics_process" : {},
+	"_input" : {},
+	"_unhandled_input" : {},
+	"_unhandled_key_input" : {}
+}
+
+##### NOTIFICATIONS #####
+
+func _set(p_property: String, p_value) -> bool:
+	if _behaviors.can_contain(p_property):
+		#warning-ignore:return_value_discarded
+		_behaviors.set_element(p_property, p_value)
+		property_list_changed_notify()
+		return true
+	return false
+
+func _get(p_property: String):
+	if _behaviors.can_contain(p_property):
+		return _behaviors.get_element(p_property)
+	return null
+
+func _get_property_list() -> Array:
+	if not _behaviors:
+		_behaviors = ResourceSet.new()
+	_behaviors.setup("_behaviors", Behavior)
+	var list := []
+	list.append(PropertyInfo.new_dictionary("_behaviors", 0, "", PROPERTY_USAGE_STORAGE).to_dict())
+	list += _behaviors.get_collection_property_list()
+	return list
+
+func _ready() -> void:
+	if not Engine.editor_hint:
+		var behaviors = _behaviors.get_data()
+		for behavior in behaviors.values():
+			_initialize_behavior(behavior)
+		
+		for behavior in _callbacks["_ready"]:
+			behavior._ready()
+	_check_for_empty_callbacks()
+
+func _process(delta: float) -> void:
+	_handle_notification("_process", delta)
+
+func _physics_process(delta: float) -> void:
+	_handle_notification("_physics_process", delta)
+
+func _input(event: InputEvent) -> void:
+	_handle_notification("_input", event)
+
+func _unhandled_input(event: InputEvent) -> void:
+	_handle_notification("_unhandled_input", event)
+
+func _unhandled_key_input(event: InputEventKey) -> void:
+	_handle_notification("_unhandled_key_input", event)
+
+##### VIRTUALS #####
+
+func _add_element(p_variable: String, p_script: Script) -> void:
+	var collection: ResourceCollection = get(p_variable)
+	collection.add_element(p_script)
+
+##### PUBLIC METHODS #####
+
+func add_behavior(p_type: Script) -> Behavior:
+	var behaviors = _behaviors.get_data()
+	
+	var ct = ClassType.new(p_type)
+	if not ct.is_type(Behavior):
+		return null
+	if has_behavior(p_type):
+		return get_behavior(p_type)
+		
+	var behavior: Behavior = p_type.new()
+	var behavior_name: String = ct.get_script_class()
+	
+	behaviors[behavior_name] = behavior
+	_initialize_behavior(behavior)
+	
+	return behavior
+
+func get_behavior(p_type: Script) -> Behavior:
+	var behaviors = _behaviors.get_data()
+	return behaviors.get(ClassType.new(p_type).get_script_class(), null);
+
+func has_behavior(p_type: Script) -> bool:
+	var behaviors = _behaviors.get_data()
+	return behaviors.has(ClassType.new(p_type).get_script_class())
+
+func remove_behavior(p_type: Script) -> bool:
+	var behaviors = _behaviors.get_data()
+	
+	var type_name := ClassType.new(p_type).get_script_class()
+	if not behaviors.has(type_name):
+		return false
+	var behavior = behaviors[type_name]
+	#warning-ignore:return_value_discarded
+	behaviors.erase(type_name)
+	_remove_from_callbacks(behavior)
+	behavior.free()
+	return true
+
+##### PRIVATE METHODS #####
+
+func _handle_notification(p_name: String, p_param) -> void:
+    for a_behavior in _callbacks[p_name]:
+        a_behavior.call(p_name, p_param)
+
+func _initialize_behavior(p_behavior: Behavior) -> void:
+	p_behavior.awake(self)
+	#warning-ignore:return_value_discarded
+	p_behavior.connect("script_changed", self, "_refresh_callbacks", [p_behavior])
+	_add_to_callbacks(p_behavior)
+
+func _add_to_callbacks(p_behavior: Behavior) -> void:
+	for callback in _callbacks:
+		if p_behavior.has_method(callback) and p_behavior.get_enabled():
+			_callbacks[callback][p_behavior] = null
+
+func _remove_from_callbacks(p_behavior: Behavior) -> void:
+	for callback in _callbacks:
+		_callbacks[callback].erase(p_behavior)
+	_check_for_empty_callbacks()
+
+func _check_for_empty_callbacks() -> void:
+	for callback_key in _callbacks:
+		match callback_key:
+			"_process":
+				set_process(not _callbacks[callback_key].empty())
+			"_physics_process":
+				set_physics_process(not _callbacks[callback_key].empty())
+			"_input":
+				set_process_input(not _callbacks[callback_key].empty())
+			"_unhandled_input":
+				set_process_unhandled_input(not _callbacks[callback_key].empty())
+			"_unhandled_key_input":
+				set_process_unhandled_key_input(not _callbacks[callback_key].empty())
+
+##### CONNECTIONS #####
+
+func _on_behavior_script_change(p_behavior: Behavior) -> void:
+	_remove_from_callbacks(p_behavior)
+	_add_to_callbacks(p_behavior)

--- a/addons/godot-next/references/property_info.gd
+++ b/addons/godot-next/references/property_info.gd
@@ -1,0 +1,62 @@
+# author: xdgamestudios
+# license: MIT
+# description: A class abstraction, for building properties to be rendered to the
+#              inspector using the method _get_property_list()
+tool
+extends Reference
+class_name PropertyInfo
+
+##### CONSTANTS #####
+
+const SELF_PATH := "res://addons/godot-next/references/property_info.gd"
+
+##### PROPERTIES #####
+
+var name: String
+var type: int
+var hint: int
+var hint_string: String
+var usage: int
+
+##### NOTIFICATIONS #####
+
+func _init(p_name: String = "", p_type: int = TYPE_NIL, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> void:
+	name = p_name
+	type = p_type
+	hint = p_hint
+	hint_string = p_hint_string
+	usage = p_usage
+
+##### PUBLIC METHODS #####
+
+func to_dict() -> Dictionary:
+	return {
+		"name": name,
+		"type": type,
+		"hint": hint,
+		"hint_string": hint_string,
+		"usage": usage
+	}
+
+static func from_dict(p_dict: Dictionary) -> PropertyInfo:
+	var name: String = p_dict.name if p_dict.has("name") else ""
+	var type: int = p_dict.type if p_dict.has("type") else TYPE_NIL
+	var hint: int = p_dict.hint if p_dict.has("hint") else PROPERTY_HINT_NONE
+	var hint_string: String = p_dict.hint_string if p_dict.has("hint_string") else ""
+	var usage: int = p_dict.usage if p_dict.has("usage") else PROPERTY_USAGE_DEFAULT
+	return load(SELF_PATH).new(name, type, hint, hint_string, usage)
+
+static func new_nil(p_name: String) -> PropertyInfo:
+	return load(SELF_PATH).new(p_name, 0, 0, "", PROPERTY_USAGE_EDITOR)
+
+static func new_group(p_name: String, p_prefix: String = "") -> PropertyInfo:
+	return load(SELF_PATH).new(p_name, 0, 0, p_prefix, PROPERTY_USAGE_GROUP)
+
+static func new_array(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
+	return load(SELF_PATH).new(p_name, TYPE_ARRAY, p_hint, p_hint_string, p_usage)
+
+static func new_dictionary(p_name: String, p_hint: int = PROPERTY_HINT_NONE, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
+	return load(SELF_PATH).new(p_name, TYPE_DICTIONARY, p_hint, p_hint_string, p_usage)
+
+static func new_resource(p_name: String, p_hint_string: String = "", p_usage: int = PROPERTY_USAGE_DEFAULT) -> PropertyInfo:
+	return load(SELF_PATH).new(p_name, TYPE_OBJECT, PROPERTY_HINT_RESOURCE_TYPE, p_hint_string, p_usage)

--- a/addons/godot-next/resources/behavior.gd
+++ b/addons/godot-next/resources/behavior.gd
@@ -1,0 +1,72 @@
+# author: xdgamestudios
+# license: MIT
+# description: This is an abstract base "Behavior" class for use in the "Behaviors" node class.
+#              "Behaviors" manages "Behavior" resources and calls notification methods that the Behavior implements.
+# usage: 
+# - Supported notifications:
+#     _ready() -> void
+#     _process(p_delta: float) -> void
+#     _physics_process(delta: float) -> void:
+#     _input(event: InputEvent) -> void:
+#     _unhandled_input(event: InputEvent) -> void:
+#     _unhandled_key_input(event: InputEventKey) -> void:
+#     Note:
+#     - If present notifications, are automatically triggered by the owner class.
+#     - If the behavior is disabled its notifications will not be processed. 
+tool
+extends Resource
+class_name Behavior
+
+##### CLASSES #####
+
+##### SIGNALS #####
+
+##### CONSTANTS #####
+
+##### EXPORTS #####
+
+##### PROPERTIES #####
+
+# `owner` is a reference to the Behaviors node.
+var owner = null setget _set_owner, get_owner
+
+# `enabled` allows to toggle on and off the bahvior processing.
+var _enabled: bool = true setget set_enabled, get_enabled
+
+##### NOTIFICATIONS #####
+
+##### OVERRIDES #####
+
+##### VIRTUALS #####
+
+##### PUBLIC METHODS #####
+
+func awake(p_owner) -> void:
+	owner = p_owner
+
+func get_behavior(p_type: Script) -> Behavior:
+	return owner.get_behavior(p_type)
+
+static func is_abstract() -> bool:
+	return true
+
+##### PRIVATE METHODS #####
+
+##### CONNECTIONS #####
+
+##### SETTERS AND GETTERS #####
+
+func set_enabled(enable: bool) -> void:
+	_enabled = enable
+	var method = "_add_to_callbacks" if _enabled else "_remove_from_callbacks"
+	owner.call(method, self)
+
+func get_enabled() -> bool:
+	return _enabled
+
+#warning-ignore:unused_argument
+func _set_owner(owner) -> void:
+	assert false
+
+func get_owner():
+	return owner

--- a/addons/godot-next/resources/resource_array.gd
+++ b/addons/godot-next/resources/resource_array.gd
@@ -1,0 +1,69 @@
+tool
+extends ResourceCollection
+class_name ResourceArray
+
+##### CONSTANTS #####
+
+const DELIMITER = "_#_"
+
+const EMPTY_ENTRY = "[ Empty ]"
+const COLLECTION_NAME = "[ Array ]"
+
+##### PROPERTIES #####
+
+var _name: = ""
+var _type: Script = null
+
+var _data: = []
+
+##### NOTIFICATIONS #####
+
+func _get_property_list() -> Array:
+	return [ PropertyInfo.new_array("_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE).to_dict() ]
+
+##### PUBLIC METHODS #####
+
+func setup(p_name: String, p_type: Script) -> void:
+	_name = p_name
+	_type = p_type
+
+func get_data() -> Array:
+	return _data
+
+func get_collection_property_list() -> Array:
+	var list = []
+	
+	if not _name or not _type:
+		return list
+		
+	var group_prefix = _name + DELIMITER
+	var item_prefix = _name + DELIMITER + "item_"
+	
+	list.append(PropertyInfo.new_group("%s %s" % [_name, COLLECTION_NAME], group_prefix).to_dict())
+	list.append(PropertyInfo.new_array(_name, PROPERTY_HINT_RESOURCE_TYPE, "#%s" % _type.get_path()).to_dict())
+	
+	if _data.empty():
+		list.append(PropertyInfo.new_nil("%s%s" % [group_prefix, EMPTY_ENTRY]).to_dict())
+	for idx in _data.size():
+		list.append(PropertyInfo.new_resource("%s%s" % [item_prefix, idx], "", PROPERTY_USAGE_EDITOR).to_dict())
+	return list
+
+func can_contain(p_property: String) -> bool:
+	if not _name or not _type:
+		return false
+	return p_property.begins_with(_name + DELIMITER) and not p_property.ends_with(EMPTY_ENTRY)
+
+func set_element(p_property: String, p_value) -> bool:
+	var index := int(p_property.lstrip(_name + DELIMITER + "item_"))
+	if not p_value:
+		_data.remove(index)
+	else:
+		_data[index] = p_value
+	return true
+
+func get_element(p_property: String):
+	var index := int(p_property.lstrip(_name + DELIMITER + "item_"))
+	return _data[index] if index < _data.size() else null
+
+func add_element(script) -> void:
+	_data.append(script.new())

--- a/addons/godot-next/resources/resource_collection.gd
+++ b/addons/godot-next/resources/resource_collection.gd
@@ -1,0 +1,22 @@
+tool
+extends Resource
+class_name ResourceCollection
+
+func can_contain(p_property: String) -> bool:
+	assert false
+	return false
+
+func add_element(p_script: Script) -> void:
+	assert false
+
+func set_element(p_property: String, p_value) -> bool:
+	assert false
+	return false
+
+func get_element(p_property: String) -> Resource:
+	assert false
+	return null
+
+func get_collection_property_list() -> Array:
+	assert false
+	return []

--- a/addons/godot-next/resources/resource_set.gd
+++ b/addons/godot-next/resources/resource_set.gd
@@ -1,0 +1,71 @@
+tool
+extends ResourceCollection
+class_name ResourceSet
+
+##### CONSTANTS #####
+
+const DELIMITER = "_?_"
+
+const EMPTY_ENTRY = "[ Empty ]"
+const COLLECTION_NAME = "[ Set ]"
+
+##### PROPERTIES #####
+
+var _name: = ""
+var _type: Script = null
+
+var _data := {}
+
+##### NOTIFICATIONS #####
+
+func _get_property_list() -> Array:
+	return [ PropertyInfo.new_dictionary("_data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE).to_dict() ]
+
+##### PUBLIC METHODS #####
+
+func setup(p_name: String, p_type: Script) -> void:
+	_name = p_name
+	_type = p_type
+
+func get_data() -> Dictionary:
+	return _data
+
+func get_collection_property_list() -> Array:
+	var list = []
+	
+	if not _name or not _type:
+		return list
+	
+	var group_prefix = _name + DELIMITER
+	var item_prefix = _name + DELIMITER
+	list.append(PropertyInfo.new_group("%s %s" % [_name, COLLECTION_NAME], group_prefix).to_dict())
+	list.append(PropertyInfo.new_dictionary(_name, PROPERTY_HINT_RESOURCE_TYPE, "#%s" % _type.get_path(), PROPERTY_USAGE_EDITOR).to_dict())
+	
+	if _data.empty():
+		list.append(PropertyInfo.new_nil("%s%s" % [group_prefix, EMPTY_ENTRY]).to_dict())
+	for item in _data:
+		list.append(PropertyInfo.new_resource("%s%s" % [item_prefix, item], "", PROPERTY_USAGE_EDITOR).to_dict())
+	return list
+
+func can_contain(p_property: String) -> bool:
+	if not _name or not _type:
+		return false
+	return p_property.begins_with(_name + DELIMITER) and not p_property.ends_with(EMPTY_ENTRY)
+
+func set_element(p_property: String, p_value) -> bool:
+	var key := p_property.lstrip(_name + DELIMITER)
+	if not p_value:
+		#warning-ignore:return_value_discarded
+		_data.erase(key)
+	else:
+		_data[key] = p_value
+	return true
+
+func get_element(p_property: String) -> Resource:
+	var key := p_property.lstrip(_name + DELIMITER)
+	return _data[key] if _data.has(key) else null
+
+func add_element(p_script: Script) -> void:
+	var key := ClassType.new(p_script).get_name()
+	if not _data.has(key):
+		_data[key] = p_script.new()


### PR DESCRIPTION
Adds a behavior system to Godot similar to the one present on Unity, as well as implements a PropertyInfo class for handling property structure and a BehaviorCollection resource capable of rendering to the inspector an editable Array or Set of a given type of resource.

1) Behaviors should inherit Behavior class (Resource type) -> similar to MonoBehaviors
2) The container for the behaviors is the class Behaviors -> similar to GameObject
3) The BehaviorCollection is the base class to the two of Collections included ResourceSet and ResourceArray

NOTE: any notification method implemented on the Behavior will automatically be connected to the BehaviorCollection (Node) and will be passed through.

here is a small demonstration of the Behavior System, making use of the new ResourceCollection system created for Godot:

![sem nome](https://user-images.githubusercontent.com/10358443/53973927-91e13280-40f9-11e9-908f-385308420e6e.gif)
