### PR TITLE
Update trail_2d.gd

### DIFF
--- a/addons/godot-next/2d/trail_2d.gd
+++ b/addons/godot-next/2d/trail_2d.gd
@@ -120,6 +120,10 @@ func _should_shrink() -> bool:
 
 ##### PUBLIC METHODS #####
 
+func erase_trail():
+	for i in range(get_point_count()):
+		remove_point(0)
+
 ##### PRIVATE METHODS #####
 
 ##### SETTERS AND GETTERS #####


### PR DESCRIPTION
convenient helper function for when an item is teleported and the trail shouldn't cross the entire map