### PR TITLE
MessageDispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ That's it! I hope you've got ideas of what you'd like to share with others.
 |[Geometry2D](addons/godot-next/2d/geometry_2d.gd)|A utility that draws a Shape2D using CollisionShape2D's editor plugin handles.|GDScript
 |[Inflector](addons/godot-next/references/inflector.gd)|A vocabulary wrapper of inflection tools to pluralize and singularize strings.|GDScript
 |[InspectorControls](addons/godot-next/global/inspector_controls.gd)|A utility for creating data-editing GUI elements.|GDScript
+|[MessageDispatcher](addons/godot-next/objects/message_dispatcher.gd)|A base object that handles signaling for non predetermined signals.|GDScript
 |[ProjectTools](addons/godot-next/global/project_tools.gd)|A utility for any features useful in the context of a Godot Project.|GDScript
 |[PropertyInfo](addons/godot-next/references/property_info.gd)|A wrapper and utility class for generating PropertyInfo Dictionaries, for use in `Object._get_property_list()`.|GDScript
 |[ResourceArray](addons/godot-next/resources/resource_collections/resource_array.gd)|A ResourceCollection implementation that manages an Array of Resources.|GDScript

--- a/addons/godot-next/nodes/message_dispatcher_wrapper.gd
+++ b/addons/godot-next/nodes/message_dispatcher_wrapper.gd
@@ -1,0 +1,33 @@
+# MessageDispatcherWrapper
+# author: MunWolf (Rikhardur Bjarni Einarsson)
+# license: MIT
+# copyright: Copyright (c) 2019 Rikhardur Bjarni Einarsson
+# brief_description: A wrapper for MessageDispatcher that is extendable on a Node,
+#                    people can also use this as a template to implement it on
+#                    their own if they want to extend something else.
+
+extends Node
+
+class_name MessageDispatcherWrapper
+
+##### PROPERTIES #####
+
+var _message_dispatcher = MessageDispatcher.new()
+
+##### PUBLIC METHODS #####
+
+# See same function on MessageDispatcher
+func connect_message(message_type: String, obj: Object, function: String) -> void:
+	_message_dispatcher.connect_message(message_type, obj, function)
+
+# See same function on MessageDispatcher
+func disconnect_message(message_type: String, obj: Object, function: String) -> void:
+	_message_dispatcher.disconnect_message(message_type, obj, function)
+
+# See same function on MessageDispatcher
+func disconnect_all_message() -> void:
+	_message_dispatcher.disconnect_all_message()
+
+# See same function on MessageDispatcher
+func emit_message(message_type: String, message_data: Dictionary) -> bool:
+	return _message_dispatcher.emit_message(message_type, message_data)

--- a/addons/godot-next/objects/message_dispatcher.gd
+++ b/addons/godot-next/objects/message_dispatcher.gd
@@ -1,0 +1,51 @@
+# MessageDispatcher
+# author: MunWolf (Rikhardur Bjarni Einarsson)
+# license: MIT
+# copyright: Copyright (c) 2019 Rikhardur Bjarni Einarsson
+# brief_description: A message handler for non predefined signals, can be extended by any class
+#                    Node, Reference, Resource etc, can also be directly attached to a Node.
+extends Object
+
+class_name MessageDispatcher
+
+##### PROPERTIES #####
+
+var _message_handlers := {}
+
+##### PUBLIC METHODS #####
+
+# Connect a handler, obj has to have a function that corresponds to the parameter.
+#    message_type: type of the message, we call obj.function(message) based on this.
+#    obj: object that holds the callback.
+#    function: function to be called on the object.
+func connect_message(message_type: String, obj: Object, function: String) -> void:
+	assert(obj.has_method(function))
+	if !_message_handlers.has(message_type):
+		_message_handlers[message_type] = []
+	
+	_message_handlers[message_type].push_back([obj, function])
+
+# Disconnect a handler, this assumes that some handler with this message type has been registered
+#    message_type: type of the message, we call obj.function(message) based on this.
+#    obj: object that holds the callback.
+#    function: function to be called on the object.
+func disconnect_message(message_type: String, obj: Object, function: String) -> void:
+	assert(_message_handlers[message_type] != null)
+	_message_handlers[message_type].erase([obj, function])
+
+# Disconnect all handlers.
+func disconnect_all_message() -> void:
+	_message_handlers = {}
+
+# Emits a message to all handlers, message can be modified by the handlers
+# and it will show up inside the dictionary that was passed by the caller.
+#    message_type: the type of the message, decides which handlers to call.
+#    message_data: extra data that can be used by the handler or where the handler can store results.
+#    return: returns if it was passed to any handler or not.
+func emit_message(message_type: String, message_data: Dictionary) -> bool:
+	var handlers = _message_handlers[message_type]
+	if handlers != null:
+		for handler in handlers:
+			handler[0].call(handler[1], message_type, message_data)
+			
+	return handlers != null && !handlers.empty()

--- a/addons/godot-next/objects/message_dispatcher.gd
+++ b/addons/godot-next/objects/message_dispatcher.gd
@@ -2,9 +2,9 @@
 # author: MunWolf (Rikhardur Bjarni Einarsson)
 # license: MIT
 # copyright: Copyright (c) 2019 Rikhardur Bjarni Einarsson
-# brief_description: A message handler for non predefined signals, can be extended by any class
-#                    Node, Reference, Resource etc, can also be directly attached to a Node.
-extends Object
+# brief_description: A message handler for non predefined signals, if you want to use this by extending it on a Node please use MessageDispatcherWrapper.
+
+extends Reference
 
 class_name MessageDispatcher
 
@@ -43,9 +43,17 @@ func disconnect_all_message() -> void:
 #    message_data: extra data that can be used by the handler or where the handler can store results.
 #    return: returns if it was passed to any handler or not.
 func emit_message(message_type: String, message_data: Dictionary) -> bool:
+	var invalid
 	var handlers = _message_handlers[message_type]
 	if handlers != null:
+		var invalid = []
 		for handler in handlers:
-			handler[0].call(handler[1], message_type, message_data)
+			if is_instance_valid(handler[0]):
+				handler[0].call(handler[1], message_type, message_data)
+			else:
+				invalid.push_back(handler)
+
+		for handler in invalid:
+			handlers.erase(handler)
 			
 	return handlers != null && !handlers.empty()

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -43,3 +43,7 @@
     - This Reference type stores a static database of all Reference-derived types which can be fetched by their script.
     - `Singletons.fetch(MyType)` will return an instance of MyType and ensure that only one instance of it is managed by the Singletons database.
     - Can implement one's own static method which converts `Singletons.fetch(MyType)` to `MyType.fetch()`.
+6. Have you ever wanted to send signals to child nodes, resources or even references but you don't want to define all the possible signals in the instance?
+    - MessageDispatcher
+    - Allows any object to register a function that handles a specific message_type.
+    - Emit a message on the dispatcher and it sends it to all relevant handlers or discards it if no handlers were registered.


### PR DESCRIPTION
Adding a message_dispatcher object.

It can be initialized by itself, attached to a Node or extended by a anything that extends Object (Node, Resource, Reference etc)

Allows for signalling without pre-defining a signal, you can for example have all child nodes of a parent node that care about damage register for a "inflict_damage" message on the dispatcher.

And any enemy can inflict_damage on any message_dispatcher but only the ones that have handlers registered will do anything with them.

This allows for a more duck typed way of emitting signals or propagating notifications.