### PR TITLE
Fix Message Dispatcher Parse Error

### DIFF
--- a/addons/godot-next/objects/message_dispatcher.gd
+++ b/addons/godot-next/objects/message_dispatcher.gd
@@ -43,7 +43,6 @@ func disconnect_all_message() -> void:
 #    message_data: extra data that can be used by the handler or where the handler can store results.
 #    return: returns if it was passed to any handler or not.
 func emit_message(message_type: String, message_data: Dictionary) -> bool:
-	var invalid
 	var handlers = _message_handlers[message_type]
 	if handlers != null:
 		var invalid = []


### PR DESCRIPTION
Previously, Godot threw "`Parse Error: Variable 'invalid' already defined in the scope`" when loading the script. The variable `invalid` was previously defined both on line 46 and line 49. I'm surprised this slipped by, as it's the first thing that Godot complained about when I loaded up the script...